### PR TITLE
php 버전정보 노출 제거

### DIFF
--- a/docker/production/php.ini
+++ b/docker/production/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+expose_php = Off


### PR DESCRIPTION
- 응답 헤더의 X-Powered-By 키값으로 인해 php 버전 특정
- php 설정으로 헤더 정보 미표시로 변경